### PR TITLE
fixed table column alignment issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "test:build": "npm run build && vite preview --port 3334"
   },
   "dependencies": {
+    "ajv": "^8.17.1",
     "katex": "^0.16.22",
     "react-markdown": "^10.1.0",
     "rehype-katex": "^7.0.1",

--- a/src/MarkdownStyles.css
+++ b/src/MarkdownStyles.css
@@ -100,7 +100,8 @@
   border-collapse: collapse;
   font-size: 0.75em;
   margin: 12px 0;
-  display: block;
+  table-layout: fixed;
+  width: 100%;
   overflow-x: auto;
   overflow-y: hidden;
   max-width: 100%;
@@ -111,7 +112,6 @@
 /* Table body structure */
 .markdown-content tbody,
 .markdown-content thead {
-  display: table;
   width: auto; /* Let it size based on content */
   min-width: 100%; /* But at least fill the container */
 }


### PR DESCRIPTION
Fixed the table column alignment issue in markdown. Table columns now align with the header.

<img width="834" height="404" alt="image" src="https://github.com/user-attachments/assets/a535feed-5f73-4bc7-860e-0d34a71e757d" />
